### PR TITLE
Apply type validation to falsy values as well

### DIFF
--- a/redisco/models/attributes.py
+++ b/redisco/models/attributes.py
@@ -78,7 +78,7 @@ class Attribute(object):
         val = getattr(instance, self.name)
         errors = []
         # type_validation
-        if val and not isinstance(val, self.acceptable_types()):
+        if val is not None and not isinstance(val, self.acceptable_types()):
             errors.append((self.name, 'bad type',))
         # validate first standard stuff
         if self.required:

--- a/tests/models.py
+++ b/tests/models.py
@@ -398,6 +398,15 @@ class ModelTestCase(RediscoTestCase):
         self.assertFalse(nin2.is_valid())
         self.assertTrue(('age', 'must be below 10') in nin2.errors)
 
+    def test_falsy_value_type_validation(self):
+        class Person(models.Model):
+            age = models.IntegerField()
+        for val in ('', {}, []):
+            p = Person(age=val)
+            self.assertFalse(p.is_valid())
+            self.assertEqual([('age', 'bad type')], p.errors)
+
+
     def test_load_object_from_key(self):
         class Schedule(models.Model):
             att = models.CharField()


### PR DESCRIPTION
For example, this instance would previously get saved:

```
class Person(models.Model):
    age = models.IntegerField()

>>> p = Person(age=[])
>>> p.save()
True
```

…and fail with a value error when loaded:

```
>>> Person.objects.get_by_id(p.id)
Traceback (most recent call last):
  File "<ipython-input-5-623349df4911>", line 1, in <module>
    Person.objects.get_by_id(p.id)
  File "redisco/models/managers.py", line 40, in get_by_id
    return self.get_model_set().get_by_id(id)
  File "redisco/models/modelset.py", line 63, in get_by_id
    return self._get_item_with_id(id)
  File "redisco/models/modelset.py", line 276, in _get_item_with_id
    instance.id = str(id)
  File "redisco/models/base.py", line 328, in id
    att.__set__(self, att.typecast_for_read(stored_attrs[att.name]))
  File "redisco/models/attributes.py", line 153, in typecast_for_read
    return int(value)
ValueError: invalid literal for int() with base 10: '[]'
```

With this patch:

```
>>> p = Person(age=[])
>>> p.save()
[('age', 'bad type')]
```
