### PR TITLE
Adding support for multiple managers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,31 @@ back scene.
 ``key`` will be used as the main key in the redis Hash (and sub objects)
 instead of the class name.
 
+
+
+Custom Managers
+---------------
+
+Managers are attached to Model attributes by looking for a ``__attr_name__``
+class attribute. If not present, then it defaults to the lowercase attribute
+name in the Model.
+
+::
+    class User(models.Model):
+        firstname = models.Attribute()
+        lastname = models.Attribute()
+        active = models.BooleanField(default=True)        
+
+        class History(models.managers.Manager):
+            pass
+
+        class ObjectsManager(models.managers.Manager):
+            __attr_name__ = "objects"
+            def get_model_set(self):
+                return super(User.ObjectsManager, self).\
+                    get_model_set().filter(active=True)
+
+
 Saving and Validating
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ You can specify some options in your Model to control the behaviour of the
 back scene.
 
 ::
+
     class User(models.Model):
         firstname = models.Attribute()
         lastname = models.Attribute()
@@ -176,6 +177,7 @@ class attribute. If not present, then it defaults to the lowercase attribute
 name in the Model.
 
 ::
+
     class User(models.Model):
         firstname = models.Attribute()
         lastname = models.Attribute()

--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -168,9 +168,10 @@ def _initialize_manager(model_class, name, bases, attrs):
 
     model_class.objects = ManagerDescriptor(Manager(model_class))
     for key, val in attrs.iteritems():
-        if isinstance(val, Manager):
+        if isinstance(val, type) and issubclass(val, Manager):
             attr_name = getattr(val, "__attr_name__", key.lower())
-            setattr(cls, attr_name, ManagerDescriptor(val))
+            descriptor = ManagerDescriptor(val(model_class))
+            setattr(model_class, attr_name, descriptor)
 
 
 class ModelOptions(object):

--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -157,11 +157,20 @@ def _initialize_key(model_class, name):
     model_class._key = Key(model_class._meta['key'] or name)
 
 
-def _initialize_manager(model_class):
+def _initialize_manager(model_class, name, bases, attrs):
     """
-    Initializes the objects manager attribute of the model.
+    Initializes the manager attributes of the model.
+    Defaults to an instance of `Manager' attached to `objects'.
+
+    A manager name is created using the `__attr_name__' class
+    attribute, or the class name in case the attribute is missing.
     """
+
     model_class.objects = ManagerDescriptor(Manager(model_class))
+    for key, val in attrs.iteritems():
+        if isinstance(val, Manager):
+            attr_name = getattr(val, "__attr_name__", key.lower())
+            setattr(cls, attr_name, ManagerDescriptor(val))
 
 
 class ModelOptions(object):
@@ -209,7 +218,7 @@ class ModelBase(type):
         _initialize_lists(cls, name, bases, attrs)
         _initialize_indices(cls, name, bases, attrs)
         _initialize_key(cls, name)
-        _initialize_manager(cls)
+        _initialize_manager(cls, name, bases, attrs)
         # if targeted by a reference field using a string,
         # override for next try
         for target, model_class, att in _deferred_refs:

--- a/redisco/models/basetests.py
+++ b/redisco/models/basetests.py
@@ -6,8 +6,10 @@ import redisco
 import unittest
 from datetime import date
 from redisco import models
+from redisco.models import managers
 from redisco.models.base import Mutex
 from dateutil.tz import tzlocal
+
 
 class Person(models.Model):
     first_name = models.CharField()
@@ -18,6 +20,17 @@ class Person(models.Model):
 
     class Meta:
         indices = ['full_name']
+
+    class Manager(managers.Manager):
+        def get(self, *args, **kwargs):
+            return super(Manager, self).get_or_create(*args, **kwargs)
+
+    class Manager2(managers.Manager):
+        __attr_name__ = "all_objects"
+
+        def get(self, *args, **kwargs):
+            return super(Manager, self).get_or_create(*args, **kwargs)
+
 
 
 class RediscoTestCase(unittest.TestCase):
@@ -119,6 +132,10 @@ class ModelTestCase(RediscoTestCase):
 
         self.assertEqual('Granny', p1.first_name)
         self.assertEqual('Goose', p1.last_name)
+
+    def test_multiple_managers_exist(self):
+        self.assertIsInstance(Person.objects, managers.Manager)
+        self.assertIsInstance(Person.all_objects, managers.Manager)
 
     def test_manager_create(self):
         person = Person.objects.create(first_name="Granny", last_name="Goose")

--- a/redisco/models/managers.py
+++ b/redisco/models/managers.py
@@ -15,6 +15,8 @@ class ManagerDescriptor(object):
 
 
 class Manager(object):
+    __attr_name__ = "objects"
+
     def __init__(self, model_class):
         self.model_class = model_class
 

--- a/redisco/models/managers.py
+++ b/redisco/models/managers.py
@@ -15,7 +15,6 @@ class ManagerDescriptor(object):
 
 
 class Manager(object):
-    __attr_name__ = "objects"
 
     def __init__(self, model_class):
         self.model_class = model_class


### PR DESCRIPTION
Hi, I'm working on a project where we use multiple managers (like the django orm) to keep models and logic separated from the rest of our code. We patched Redisco to add such functionality, and we though you might be interested on it.