### PR TITLE
Allow for callable defaults.

### DIFF
--- a/redisco/models/attributes.py
+++ b/redisco/models/attributes.py
@@ -51,8 +51,12 @@ class Attribute(object):
         try:
             return getattr(instance, '_' + self.name)
         except AttributeError:
-            self.__set__(instance, self.default)
-            return self.default
+            if callable(self.default):
+                default = self.default()
+            else:
+                default = self.default
+            self.__set__(instance, default)
+            return default
 
     def __set__(self, instance, value):
         setattr(instance, '_' + self.name, value)

--- a/redisco/models/basetests.py
+++ b/redisco/models/basetests.py
@@ -105,6 +105,23 @@ class ModelTestCase(RediscoTestCase):
         self.assertEqual(False, u.disliked)
         self.assertEqual(199, u.views)
 
+    def test_callable_default_CharField_val(self):
+        class User(models.Model):
+            views = models.IntegerField(default=lambda: 199)
+            liked = models.BooleanField(default=lambda: True)
+            disliked = models.BooleanField(default=lambda: False)
+
+        u = User()
+        self.assertEqual(True, u.liked)
+        self.assertEqual(False, u.disliked)
+        self.assertEqual(199, u.views)
+        assert u.save()
+
+        u = User.objects.all()[0]
+        self.assertEqual(True, u.liked)
+        self.assertEqual(False, u.disliked)
+        self.assertEqual(199, u.views)
+
     def test_getitem(self):
         person1 = Person(first_name="Granny", last_name="Goose")
         person1.save()


### PR DESCRIPTION
For example, a method which returns str(uuid.uuid4()) could be set
as the default for an attribute.