### PR TITLE
add __getitem__ to ModelBase for [] call syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dump.rdb
 /.pyflymakercc
 /.emacs.desktop
 /redisco/.ropeproject/config.py
+.ropeproject

--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -217,6 +217,8 @@ class ModelBase(type):
                 att._target_type = cls
                 _initialize_referenced(model_class, att)
 
+    def __getitem__(self, id):
+        return self.objects.get_by_id(id)
 
 class Model(object):
     __metaclass__ = ModelBase


### PR DESCRIPTION
Hi, i have add `\_\_getitem\_\_` method for ModelBase class, so i can to write `Model[id]` instead of  `Model.objects.get_by_id()`, Although the modification is small, but I think it is useful. Already test passed.

Thank you for create this repo, it's really nice. 

```py
from redisco import models

class Person(models.Model):
    name = models.Attribute(required=True, unique=True, indexed=True)
    
Person(name="debugger").save()
p = Person.objects.filter(name="debugger").first()

print p.id
print Person.objects.get_by_id(p.id)
# short code for above
print Person[p.id]
```