### PR TITLE
Fixed bug in Models.save() and added unittests for it.

### DIFF
--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -316,7 +316,7 @@ class Model(object):
         >>> f.delete()
         """
         if not self.is_valid():
-            return self._errors
+            return False
         _new = self.is_new()
         if _new:
             self._initialize_id()

--- a/redisco/models/basetests.py
+++ b/redisco/models/basetests.py
@@ -10,7 +10,7 @@ from redisco.models.base import Mutex
 from dateutil.tz import tzlocal
 
 class Person(models.Model):
-    first_name = models.CharField()
+    first_name = models.CharField(required=True)
     last_name = models.CharField()
 
     def full_name(self):
@@ -54,6 +54,15 @@ class ModelTestCase(RediscoTestCase):
 
         jejomar = Person.objects.get_by_id('2')
         self.assertEqual(None, jejomar.last_name)
+
+    def test_save_succeed(self):
+        person = Person(first_name="Granny")
+        self.assertTrue(person.save())
+
+    def test_save_fail(self):
+        person = Person(last_name="Goose")
+        self.assertFalse(person.save())
+        self.assertEqual([('first_name', 'required')], person.errors)
 
     def test_unicode(self):
         p = Person(first_name=u"Niña", last_name="Jose")


### PR DESCRIPTION
Currently, the `Model.save()` method return `Model.errors` list instead of `False`, which is inconsistent with the document.

> To save an object, call its save method. This returns True on success (i.e. when the object is valid) and False otherwise.

Therefore, if we write code like `if Model.save(): # do something`, it will fail silently. So I proposed this fix. Thanks!