### PR TITLE
Travis - start redis server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+services:
+  - redis-server
 # command to install redisco with dependencies
 install:
   - pip install . --use-mirrors

--- a/redisco/models/base.py
+++ b/redisco/models/base.py
@@ -768,6 +768,8 @@ class Mutex(object):
                     continue
 
     def lock_has_expired(self, lock):
+        if lock is None:
+            lock = 0.
         return float(lock) < time.time()
 
     def unlock(self):


### PR DESCRIPTION
Actually start the redis server, then we can see some tests failing:


The same tests fail on my local machine now
```
$  nosetests --with-doctest
/home/stu/.virtualenvs/tmp-5d68cc09a2ab3eed/local/lib/python2.7/site-packages/redis/connection.py:46: UserWarning: redis-py works best with hiredis >= 0.1.4. You're running hiredis 0.1.1. Please consider upgrading.
  warnings.warn(msg)
.....................................F...F...................................................................................
======================================================================
FAIL: Doctest: redisco.models.base.Model.is_valid
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for redisco.models.base.Model.is_valid
  File "/home/stu/projects/external/redisco/redisco/models/base.py", line 227, in is_valid

----------------------------------------------------------------------
File "/home/stu/projects/external/redisco/redisco/models/base.py", line 244, in redisco.models.base.Model.is_valid
Failed example:
    f.save()
Expected:
    ['bar', 'Invalid value']
Got:
    False


======================================================================
FAIL: Doctest: redisco.models.base.Model.validate
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for redisco.models.base.Model.validate
  File "/home/stu/projects/external/redisco/redisco/models/base.py", line 260, in validate

----------------------------------------------------------------------
File "/home/stu/projects/external/redisco/redisco/models/base.py", line 275, in redisco.models.base.Model.validate
Failed example:
    f.save()
Expected:
    [('name', 'cannot be Invalid')]
Got:
    False


----------------------------------------------------------------------
Ran 125 tests in 3.299s

FAILED (failures=2)
****
```