### PR TITLE
fix _max_score always return None

### DIFF
--- a/redisco/containers.py
+++ b/redisco/containers.py
@@ -831,7 +831,7 @@ class SortedSet(Container):
         Returns the maximum score in the SortedSet.
         """
         try:
-            self.zscore(self.__getitem__(-1))
+            return self.zscore(self.__getitem__(-1))
         except IndexError:
             return None
 


### PR DESCRIPTION
I made some changes.Please review.
No test case because _max_score is not used now.
